### PR TITLE
Triplestore

### DIFF
--- a/install/Vagrantfile
+++ b/install/Vagrantfile
@@ -33,7 +33,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :path => "drupal.sh", :args => home_dir
   config.vm.provision :shell, :path => "fcrepo.sh", :args => home_dir
   config.vm.provision :shell, :path => "solr.sh"
-  config.vm.provision :shell, :path => "fuseki.sh"
+  if ENV['TRIPLESTORE'] == 'blazegraph'
+    config.vm.provision :shell, :path => "blazegraph.sh"
+    config.vm.provision :shell, :path => "fcrepo-camel-toolbox.sh", :args => 'blazegraph'
+  else
+    config.vm.provision :shell, :path => "fuseki.sh"
+    config.vm.provision :shell, :path => "fcrepo-camel-toolbox.sh", :args => 'fuseki'
+  end
   config.vm.provision :shell, :path => "sync.sh", :args => home_dir
   config.vm.provision :shell, :path => "services.sh", :args => home_dir
   config.vm.provision :shell, :path => "post-install.sh", :args => home_dir

--- a/install/blazegraph.sh
+++ b/install/blazegraph.sh
@@ -1,0 +1,12 @@
+BLAZEGRAPH_VERSION=1.5.1
+echo "Installing BlazeGraph's NanoSparqlServer"
+
+cd /var/lib/tomcat7/webapps
+wget -q -O bigdata.war "http://sourceforge.net/projects/bigdata/files/bigdata/$BLAZEGRAPH_VERSION/bigdata.war/download"
+chown tomcat7:tomcat7 bigdata.war
+
+if [ $(grep -c 'com.bigdata.rdf.sail.webapp' /etc/default/tomcat7) -eq 0 ]; then
+	echo "JAVA_OPTS=\"\$JAVA_OPTS -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=/var/lib/tomcat7/webapps/bigdata/WEB-INF/RWStore.properties\"" >> /etc/default/tomcat7
+fi
+
+service tomcat7 restart

--- a/install/fcrepo-camel-toolbox.sh
+++ b/install/fcrepo-camel-toolbox.sh
@@ -1,0 +1,17 @@
+echo "Installing Fcrepo-Camel-Toolbox"
+
+CAMEL_VERSION=4.2.0
+TRIPLESTORE=$1
+
+cd /var/lib/tomcat7/webapps
+wget -O fcrepo-camel-toolbox.war "https://github.com/fcrepo4-labs/fcrepo-camel-toolbox/releases/download/fcrepo-camel-toolbox-$CAMEL_VERSION/fcrepo-camel-webapp-at-is-it-$CAMEL_VERSION.war"
+chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fcrepo-camel-toolbox.war
+
+if [ $(grep -c '\-Dtriplestore.baseUrl=' /etc/default/tomcat7) -eq 0 ]; then
+  if [ "$TRIPLESTORE" == 'fuseki' ]; then
+  	echo "JAVA_OPTS=\"\$JAVA_OPTS -Dtriplestore.baseUrl=localhost:8080/fuseki/test/update\"" >> /etc/default/tomcat7
+  elif [ "$TRIPLESTORE" == 'blazegraph' ]; then
+  	echo "JAVA_OPTS=\"\$JAVA_OPTS -Dtriplestore.baseUrl=localhost:8080/bigdata/sparql\"" >> /etc/default/tomcat7
+  fi
+fi
+/etc/init.d/tomcat7 restart

--- a/install/fuseki.sh
+++ b/install/fuseki.sh
@@ -11,4 +11,9 @@ tar -xzvf apache-jena-fuseki-"$FUSEKI_VERSION".tar.gz
 cd apache-jena-fuseki-"$FUSEKI_VERSION"
 mv -v fuseki.war $FUSEKI_DEPLOY
 chown -hR tomcat7:tomcat7 $FUSEKI_DEPLOY/fuseki.war
+
 service tomcat7 restart
+sleep 20
+sed -i 's|^\/$\/\*\* = localhost|\#\/$\/\*\* = localhost|g' $FUSEKI_BASE/shiro.ini
+service tomcat7 restart
+


### PR DESCRIPTION
Adding in fcrepo-camel-toolbox for triplestore indexing
Adding BlazeGraph as a possible triplestore.
Allow environment variable TRIPLESTORE to choose the triplestore to install.

Assists in #30 

To use BlazeGraph run
```TRIPLESTORE=blazegraph vagrant up```

otherwise Fuseki is installed, but does not work yet.