### PR TITLE
added basic tests to image service

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -20,6 +20,7 @@
     <commons-io.version>2.4</commons-io.version>
     <fcrepo.camel.version>4.3.0</fcrepo.camel.version>
     <slf4j.version>1.7.12</slf4j.version>
+    <scriptengines-javascript.version>1.1.1</scriptengines-javascript.version>
     <log4j.version>1.2.17</log4j.version>
     <!-- plugins -->
     <compiler.plugin.version>2.5.1</compiler.plugin.version>
@@ -53,13 +54,59 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
+        <artifactId>camel-mustache</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-http4</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-cache</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-script</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-base64</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
         <artifactId>camel-exec</artifactId>
         <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>activemq-camel</artifactId>
+        <version>${activemq.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.fcrepo.camel</groupId>
+        <artifactId>fcrepo-camel</artifactId>
+        <version>${fcrepo.camel.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.scriptengines</groupId>
+        <artifactId>scriptengines-javascript</artifactId>
+        <version>${scriptengines-javascript.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-jetty9</artifactId>
+        <version>${camel.version}</version>
       </dependency>
 
       <!-- logging -->

--- a/camel/services/basic-image-service/pom.xml
+++ b/camel/services/basic-image-service/pom.xml
@@ -16,6 +16,10 @@
 
   <name>Islandora Basic Image Service</name>
 
+  <properties>
+    <scriptengines-javascript.version>1.1.1</scriptengines-javascript.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.camel</groupId>
@@ -23,9 +27,37 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-mustache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-jetty9</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-blueprint</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-script</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>fcrepo-camel</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.scriptengines</groupId>
+      <artifactId>scriptengines-javascript</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ca.islandora.camel.component</groupId>
+      <artifactId>islandora-camel-component</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- logging -->
     <dependency>
@@ -46,6 +78,12 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-blueprint</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -82,6 +120,12 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18.1</version>
       </plugin>
 
       <plugin>

--- a/camel/services/basic-image-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/camel/services/basic-image-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,6 +9,7 @@
 
   <!-- Load Configuration File -->
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.services.basic.image" update-strategy="reload">
+
     <cm:default-properties>
       <cm:property name="islandora.drupal.baseurl" value="localhost/islandora"/>
       <cm:property name="islandora.drupal.username" value=""/>
@@ -32,7 +33,7 @@
     <routeContextRef ref="put"/>
     <routeContextRef ref="delete"/>
 
-    <route>
+    <route id="changeme3">
       <from uri="jetty:http://0.0.0.0:8888/islandora/rest/basic-image/"/>
         <choice>
           <when><simple>${headers.CamelHttpMethod} == 'GET'</simple>

--- a/camel/services/basic-image-service/src/main/resources/OSGI-INF/blueprint/get.xml
+++ b/camel/services/basic-image-service/src/main/resources/OSGI-INF/blueprint/get.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sparql="http://www.w3.org/2005/sparql-results#"
            xsi:schemaLocation="
            http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
@@ -21,19 +21,19 @@
         <transform><javaScript>encodeURI(request.body)</javaScript></transform>
         <removeHeaders pattern="*"/>
         <setHeader headerName="CamelHttpMethod"><constant>POST</constant></setHeader>
-        <setHeader headerName="CamelHttpQuery"><simple>format=json&amp;query=${bodyAs(String)}</simple></setHeader>
+        <setHeader headerName="CamelHttpQuery"><simple>format=xml&amp;query=${bodyAs(String)}</simple></setHeader>
         <setBody><simple>${null}</simple></setBody>
         <to uri="http:{{islandora.triplestore.baseurl}}"/>
         <to uri="direct:getObjectExtractUri"/>
     </route>
 
     <route id="getObjectExtractUri">
-      <description>Uses JSONPath and Javascript to parse SPARQL query results and set collection URI as an exchange property</description>
+      <description>Uses XPath and Javascript to parse SPARQL query results and set collection URI as an exchange property</description>
       <from uri="direct:getObjectExtractUri"/>
         <doTry>
-          <transform><jsonpath>$['results']['bindings'][0]['s']['value']</jsonpath></transform>
+          <transform><xpath resultType="java.lang.String">//sparql:results/sparql:result[1]/sparql:binding[@name='s']/sparql:uri/text()</xpath></transform>
           <transform><javaScript>request.body.substr(request.body.indexOf('://') + 3)</javaScript></transform>
-          <setProperty propertyName="uri"><simple>${bodyAs(String)}</simple></setProperty>
+          <setProperty propertyName="uri"><simple>${body}</simple></setProperty>
           <doCatch>
             <exception>java.lang.Exception</exception>
             <to uri="direct:getObjectExtractUriError"/>
@@ -65,19 +65,19 @@
         <transform><javaScript>encodeURI(request.body)</javaScript></transform>
         <removeHeaders pattern="*"/>
         <setHeader headerName="CamelHttpMethod"><constant>POST</constant></setHeader>
-        <setHeader headerName="CamelHttpQuery"><simple>format=json&amp;query=${bodyAs(String)}</simple></setHeader>
+        <setHeader headerName="CamelHttpQuery"><simple>format=xml&amp;query=${bodyAs(String)}</simple></setHeader>
         <setBody><simple>${null}</simple></setBody>
         <to uri="http:{{islandora.triplestore.baseurl}}"/>
         <to uri="direct:getCollectionExtractUri"/>
     </route>
 
     <route id="getCollectionExtractUri">
-      <description>Uses JSONPath and Javascript to parse SPARQL query results and set collection URI as an exchange property</description>
+      <description>Uses XPath and Javascript to parse SPARQL query results and set collection URI as an exchange property</description>
       <from uri="direct:getCollectionExtractUri"/>
         <doTry>
-          <transform><jsonpath>$['results']['bindings'][0]['s']['value']</jsonpath></transform>
+          <transform><xpath resultType="java.lang.String">//sparql:results/sparql:result[1]/sparql:binding[@name='s']/sparql:uri/text()</xpath></transform>
           <transform><javaScript>request.body.substr(request.body.indexOf('://') + 3)</javaScript></transform>
-          <setProperty propertyName="uri"><simple>${bodyAs(String)}</simple></setProperty>
+          <setProperty propertyName="uri"><simple>${body}</simple></setProperty>
           <doCatch>
             <exception>java.lang.Exception</exception>
             <to uri="direct:getCollectionExtractUriError"/>

--- a/camel/services/basic-image-service/src/test/java/ca/islandora/services/basic/image/GetRoutesTest.java
+++ b/camel/services/basic-image-service/src/test/java/ca/islandora/services/basic/image/GetRoutesTest.java
@@ -1,0 +1,126 @@
+package ca.islandora.services.basic.image;
+
+import static java.util.UUID.randomUUID;
+import static org.apache.camel.Exchange.HTTP_METHOD;
+import static org.apache.camel.Exchange.HTTP_QUERY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import javax.activation.DataHandler;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.apache.camel.util.ObjectHelper;
+
+import org.junit.Test;
+
+/**
+ * Test the route workflow.
+ *
+ * @author Aaron Coburn
+ * @since 2015-10-07
+ */
+public class GetRoutesTest extends CamelBlueprintTestSupport {
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Override
+    protected String getBlueprintDescriptor() {
+        return "/OSGI-INF/blueprint/*.xml";
+    }
+
+    @Test
+    public void getObjectUri() throws Exception {
+        context.getRouteDefinition("getObjectUri").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("direct:*");
+                mockEndpointsAndSkip("http:*");
+                weaveAddLast().to("mock:result");
+            }
+        });
+
+        context.start();
+
+        final String uuid = randomUUID().toString();
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedPropertyReceived("uuid", uuid);
+        resultEndpoint.message(0).header(HTTP_METHOD).equals("POST");
+        resultEndpoint.message(0).header(HTTP_QUERY).equals(
+                "format=xml&query=" +
+                "PREFIX%20nfo:%20%3chttp://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.2/%3e%0a" +
+                "PREFIX%20rdf:%20%3chttp://www.w3.org/1999/02/22-rdf-syntax-ns#%3e%0a" +
+                "PREFIX%20pcdm:%20%3chttp://pcdm.org/models#%3e%0a" +
+                "SELECT%20?s%20WHERE%20%7b%0a" +
+                "%20%20?s%20nfo:uuid%20%22" + uuid + "%22%5e%5e%3chttp://www.w3.org/2001/XMLSchema#string%3e%20.%0a" +
+                "%20%20?s%20rdf:type%20pcdm:Object%20.%0a%7d%0a");
+
+        final Exchange exchange = new DefaultExchange(context);
+        exchange.setProperty("uuid", uuid);
+
+        template.send(exchange);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void getCollectionUri() throws Exception {
+        context.getRouteDefinition("getCollectionUri").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("direct:*");
+                mockEndpointsAndSkip("http:*");
+                weaveAddLast().to("mock:result");
+            }
+        });
+
+        context.start();
+
+        final String uuid = randomUUID().toString();
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedPropertyReceived("uuid", uuid);
+        resultEndpoint.message(0).header(HTTP_METHOD).equals("POST");
+        resultEndpoint.message(0).header(HTTP_QUERY).equals(
+                "format=xml&query=" +
+                "PREFIX%20nfo:%20%3chttp://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.2/%3e%0a" +
+                "PREFIX%20rdf:%20%3chttp://www.w3.org/1999/02/22-rdf-syntax-ns#%3e%0a" +
+                "PREFIX%20pcdm:%20%3chttp://pcdm.org/models#%3e%0a" +
+                "SELECT%20?s%20WHERE%20%7b%0a" +
+                "%20%20?s%20nfo:uuid%20%22" + uuid + "%22%5e%5e%3chttp://www.w3.org/2001/XMLSchema#string%3e%20.%0a" +
+                "%20%20?s%20rdf:type%20pcdm:Collection%20.%0a%7d%0a");
+
+        final Exchange exchange = new DefaultExchange(context);
+        exchange.setProperty("uuid", uuid);
+
+        template.send(exchange);
+
+        assertMockEndpointsSatisfied();
+    }
+}

--- a/camel/services/basic-image-service/src/test/java/ca/islandora/services/basic/image/RestEndpointTest.java
+++ b/camel/services/basic-image-service/src/test/java/ca/islandora/services/basic/image/RestEndpointTest.java
@@ -1,0 +1,200 @@
+package ca.islandora.services.basic.image;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import javax.activation.DataHandler;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.apache.camel.util.ObjectHelper;
+
+import org.junit.Test;
+
+/**
+ * Test the route workflow.
+ *
+ * @author Aaron Coburn
+ * @since 2015-10-07
+ */
+public class RestEndpointTest extends CamelBlueprintTestSupport {
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Override
+    protected String getBlueprintDescriptor() {
+        return "/OSGI-INF/blueprint/*.xml";
+    }
+
+    @Test
+    public void getImage() throws Exception {
+        context.getRouteDefinition("changeme3").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("*");
+            }
+        });
+        context.start();
+
+        final String uuid = "foo";
+
+        getMockEndpoint("mock:direct:getCollectionUri").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:getBasicImage").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:getBasicImage").expectedPropertyReceived("uuid", uuid);
+        getMockEndpoint("mock:direct:createBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:deleteBasicImage").expectedMessageCount(0);
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(Exchange.HTTP_METHOD, "GET");
+        headers.put("uuid", uuid);
+
+        template.sendBodyAndHeaders(null, headers);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void createImage() throws Exception {
+        context.getRouteDefinition("changeme3").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("*");
+            }
+        });
+        context.start();
+
+        final String uuid = "foo";
+        final String node = "bar";
+        final String mimetype = "text/plain";
+        final DataHandler attachment = new DataHandler("some text", mimetype);
+
+        getMockEndpoint("mock:direct:getBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedPropertyReceived("uuid", uuid);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedPropertyReceived("node", node);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedPropertyReceived("attachment", attachment);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedPropertyReceived("mimetype", mimetype);
+        getMockEndpoint("mock:direct:createBasicImage").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:createBasicImage").expectedPropertyReceived("uuid", uuid);
+        getMockEndpoint("mock:direct:createBasicImage").expectedPropertyReceived("node", node);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedPropertyReceived("attachment", attachment);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedPropertyReceived("mimetype", mimetype);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:deleteBasicImage").expectedMessageCount(0);
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(Exchange.HTTP_METHOD, "POST");
+        headers.put("uuid", uuid);
+        headers.put("node", node);
+        headers.put("mimetype", mimetype);
+
+        final Exchange exchange = new DefaultExchange(context);
+        final Message message = new DefaultMessage();
+        message.addAttachment("key", attachment);
+        message.setHeaders(headers);
+        exchange.setIn(message);
+
+        template.send(exchange);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void updateImage() throws Exception {
+        context.getRouteDefinition("changeme3").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("*");
+            }
+        });
+        context.start();
+
+        final String uuid = "foo";
+        final String node = "bar";
+        final String mimetype = "text/plain";
+        final DataHandler attachment = new DataHandler("some text", mimetype);
+
+        getMockEndpoint("mock:direct:getBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:getCollectionUri").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:createBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedPropertyReceived("uuid", uuid);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedPropertyReceived("node", node);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedPropertyReceived("mimetype", mimetype);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedPropertyReceived("attachment", attachment);
+        getMockEndpoint("mock:direct:deleteBasicImage").expectedMessageCount(0);
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(Exchange.HTTP_METHOD, "PUT");
+        headers.put("uuid", uuid);
+        headers.put("node", node);
+        headers.put("mimetype", mimetype);
+
+        final Exchange exchange = new DefaultExchange(context);
+        final Message message = new DefaultMessage();
+        message.addAttachment("key", attachment);
+        message.setHeaders(headers);
+        exchange.setIn(message);
+
+        template.send(exchange);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void deleteImage() throws Exception {
+        context.getRouteDefinition("changeme3").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("*");
+            }
+        });
+        context.start();
+
+        final String uuid = "foo";
+
+        getMockEndpoint("mock:direct:getCollectionUri").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:getBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:createBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:updateBasicImage").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:deleteBasicImage").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:deleteBasicImage").expectedPropertyReceived("uuid", uuid);
+
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(Exchange.HTTP_METHOD, "DELETE");
+        headers.put("uuid", uuid);
+
+        template.sendBodyAndHeaders(null, headers);
+
+        assertMockEndpointsSatisfied();
+    }
+
+}

--- a/camel/services/basic-image-service/src/test/java/ca/islandora/services/basic/image/SparqlRouteTest.java
+++ b/camel/services/basic-image-service/src/test/java/ca/islandora/services/basic/image/SparqlRouteTest.java
@@ -1,0 +1,152 @@
+package ca.islandora.services.basic.image;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import javax.activation.DataHandler;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.commons.io.IOUtils;
+
+import org.junit.Test;
+
+/**
+ * Test the route workflow.
+ *
+ * @author Aaron Coburn
+ * @since 2015-10-07
+ */
+public class SparqlRouteTest extends CamelBlueprintTestSupport {
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Override
+    protected String getBlueprintDescriptor() {
+        return "/OSGI-INF/blueprint/*.xml";
+    }
+
+    @Test
+    public void getObjectExtractUri() throws Exception {
+        context.getRouteDefinition("getObjectExtractUri").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpoints("*");
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedBodiesReceived("example.org/book/book5");
+
+        template.sendBody(IOUtils.toString(ObjectHelper.loadResourceAsStream("sparql.xml"), "UTF-8"));
+
+        assertMockEndpointsSatisfied();
+
+    }
+
+    @Test
+    public void getObjectExtractUriError() throws Exception {
+        context.getRouteDefinition("getObjectExtractUri").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpoints("*");
+            }
+        });
+
+        context.getRouteDefinition("getObjectExtractUriError").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        getMockEndpoint("mock:direct:getObjectExtractUriError").expectedMessageCount(1);
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived("Content-Type", "text/plain");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 500);
+        resultEndpoint.message(0).body().startsWith("Failure extracting URI for object");
+
+        template.sendBody("this ain't xml");
+
+        assertMockEndpointsSatisfied();
+
+    }
+
+    @Test
+    public void getCollectionExtractUri() throws Exception {
+        context.getRouteDefinition("getCollectionExtractUri").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpoints("*");
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedBodiesReceived("example.org/book/book5");
+
+        template.sendBody(IOUtils.toString(ObjectHelper.loadResourceAsStream("sparql.xml"), "UTF-8"));
+
+        assertMockEndpointsSatisfied();
+
+    }
+
+    @Test
+    public void getCollectionExtractUriError() throws Exception {
+        context.getRouteDefinition("getCollectionExtractUri").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpoints("*");
+            }
+        });
+
+        context.getRouteDefinition("getCollectionExtractUriError").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        getMockEndpoint("mock:direct:getCollectionExtractUriError").expectedMessageCount(1);
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived("Content-Type", "text/plain");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 500);
+        resultEndpoint.message(0).body().startsWith("Failure extracting URI for collection");
+
+        template.sendBody("this ain't xml");
+
+        assertMockEndpointsSatisfied();
+    }
+}

--- a/camel/services/basic-image-service/src/test/resources/sparql.xml
+++ b/camel/services/basic-image-service/src/test/resources/sparql.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="s"/>
+    <variable name="o"/>
+    <variable name="p"/>
+  </head>
+  <results>
+    <result>
+      <binding name="s">
+        <uri>http://example.org/book/book5</uri>
+      </binding>
+      <binding name="o">
+        <uri>http://purl.org/dc/elements/1.1/title</uri>
+      </binding>
+      <binding name="p">
+        <literal>Harry Potter and the Order of the Phoenix</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="s">
+        <uri>http://example.org/book/book6</uri>
+      </binding>
+      <binding name="o">
+        <uri>http://purl.org/dc/elements/1.1/creator</uri>
+      </binding>
+      <binding name="p">
+        <literal>J.K. Rowling</literal>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/camel/sync/pom.xml
+++ b/camel/sync/pom.xml
@@ -25,6 +25,31 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-blueprint</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-base64</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-camel</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>fcrepo-camel</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ca.islandora.camel.component</groupId>
+      <artifactId>islandora-camel-component</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- logging -->
     <dependency>


### PR DESCRIPTION
This makes a small step toward having the basic-image-service testable. It tests the jetty endpoint routes and the `get.xml` routes (I replaced jsonpath with XPath, because the jsonpath dependency chain causes all sorts of problems with testing, and XPath is more solidly supported by camel).

Other than the jsonpath -> XPath conversion (see the accompanying tests), the only actual change to the routes themselves was to add a routeId to the jetty-based routes. This is "changeme3" because it will conflict with https://github.com/Islandora-Labs/islandora/pull/47 Once that is merged, "changeme3" can be removed.