### PR TITLE
increment version to 0.0.1-SNAPSHOT

### DIFF
--- a/camel/commands/bin/islandora.php
+++ b/camel/commands/bin/islandora.php
@@ -33,7 +33,7 @@ try {
         $std_err->writeln("\n" . $event->getException()->getTraceAsString());
     });
 
-    $application = new Application('Islandora Command Tool', '0.0.0-SNAPSHOT');
+    $application = new Application('Islandora Command Tool', '0.0.1-SNAPSHOT');
     $application->setDispatcher($dispatcher);
 
     // A little magic to find all IslandoraCommand classes and dynamically

--- a/camel/component/pom.xml
+++ b/camel/component/pom.xml
@@ -4,14 +4,12 @@
   <parent>
     <groupId>ca.islandora.camel</groupId>
     <artifactId>islandora-parent</artifactId>
-    <version>0.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.camel.component</groupId>
   <artifactId>islandora-camel-component</artifactId>
   <packaging>bundle</packaging>
-
-  <version>0.0.0-SNAPSHOT</version>
 
   <name>Islandora Camel Component</name>
 

--- a/camel/karaf/pom.xml
+++ b/camel/karaf/pom.xml
@@ -6,13 +6,12 @@
   <parent>
     <groupId>ca.islandora.camel</groupId>
     <artifactId>islandora-parent</artifactId>
-    <version>0.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.camel</groupId>
   <artifactId>islandora-karaf</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.0-SNAPSHOT</version>
 
   <name>Karaf Provisioning Features for Islandora</name>
 

--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -6,7 +6,7 @@
   <groupId>ca.islandora.camel</groupId>
   <artifactId>islandora-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.0-SNAPSHOT</version>
+  <version>0.0.1-SNAPSHOT</version>
 
   <name>Islandora :: Parent POM</name>
 

--- a/camel/services/basic-image-service/pom.xml
+++ b/camel/services/basic-image-service/pom.xml
@@ -6,13 +6,12 @@
   <parent>
       <groupId>ca.islandora.camel</groupId>
       <artifactId>islandora-services</artifactId>
-      <version>0.0.0-SNAPSHOT</version>
+      <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.camel.services</groupId>
   <artifactId>islandora-basic-image-service</artifactId>
   <packaging>bundle</packaging>
-  <version>0.0.0-SNAPSHOT</version>
 
   <name>Islandora Basic Image Service</name>
 

--- a/camel/services/collection-service/pom.xml
+++ b/camel/services/collection-service/pom.xml
@@ -6,13 +6,12 @@
   <parent>
     <groupId>ca.islandora.camel</groupId>
     <artifactId>islandora-services</artifactId>
-    <version>0.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.camel.services</groupId>
   <artifactId>islandora-collection-service</artifactId>
   <packaging>bundle</packaging>
-  <version>0.0.0-SNAPSHOT</version>
 
   <name>Islandora Collection Service</name>
 

--- a/camel/services/pom.xml
+++ b/camel/services/pom.xml
@@ -6,13 +6,12 @@
   <parent>
       <groupId>ca.islandora.camel</groupId>
       <artifactId>islandora-parent</artifactId>
-      <version>0.0.0-SNAPSHOT</version>
+      <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.camel</groupId>
   <artifactId>islandora-services</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.0-SNAPSHOT</version>
 
   <name>Islandora :: Services</name>
 

--- a/camel/sync/pom.xml
+++ b/camel/sync/pom.xml
@@ -6,13 +6,12 @@
   <parent>
     <groupId>ca.islandora.camel</groupId>
     <artifactId>islandora-parent</artifactId>
-    <version>0.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.camel.sync</groupId>
   <artifactId>islandora-sync-gateway</artifactId>
   <packaging>bundle</packaging>
-  <version>0.0.0-SNAPSHOT</version>
 
   <name>Islandora Sync Gateway</name>
 

--- a/docs/technical-documentation/commands.md
+++ b/docs/technical-documentation/commands.md
@@ -11,7 +11,7 @@ In your git project's root, head on over to the `bin` folder of the `camel/comma
 ```bash
 vagrant@islandora:~/islandora$ cd camel/commands/bin
 vagrant@islandora:~/islandora/camel/commands/bin$ php islandora.php
-Islandora Command Tool version 0.0.0-SNAPSHOT
+Islandora Command Tool version 0.0.1-SNAPSHOT
 
 Usage:
  command [options] [arguments]
@@ -188,7 +188,7 @@ So let's try it out! Go back to the `camel/commands/bin` directory and get a lis
 ```bash
 vagrant@islandora:~/islandora/camel/commands/bin$ cd ~/islandora/camel/commands/bin
 vagrant@islandora:~/islandora/camel/commands/bin$ php islandora.php
-Islandora Command Tool version 0.0.0-SNAPSHOT
+Islandora Command Tool version 0.0.1-SNAPSHOT
 
 Usage:
  command [options] [arguments]
@@ -290,7 +290,7 @@ This command is almost exactly the same as the last, except it extends JsonInput
 Let's make sure the command is available.
 ```bash
 vagrant@islandora:~/islandora/camel/commands/bin$ php islandora.php
-Islandora Command Tool version 0.0.0-SNAPSHOT
+Islandora Command Tool version 0.0.1-SNAPSHOT
 
 Usage:
  command [options] [arguments]

--- a/docs/technical-documentation/islandora-component.md
+++ b/docs/technical-documentation/islandora-component.md
@@ -40,7 +40,7 @@ You can see a list of all available namespaces and commands at any time by going
 ```bash
 vagrant@islandora:~$ cd ~/islandora/camel/commands/bin
 vagrant@islandora:~/islandora/camel/commands/bin$ php islandora.php
-Islandora Command Tool version 0.0.0-SNAPSHOT
+Islandora Command Tool version 0.0.1-SNAPSHOT
 
 Usage:
   command [options] [arguments]

--- a/install/configs/karaf/watch.script
+++ b/install/configs/karaf/watch.script
@@ -1,5 +1,5 @@
-bundle:watch --start mvn:ca.islandora.camel.component/islandora-camel-component/0.0.0-SNAPSHOT
-bundle:watch --start mvn:ca.islandora.camel.sync/islandora-sync-gateway/0.0.0-SNAPSHOT
-bundle:watch --start mvn:ca.islandora.camel.services/islandora-collection-service/0.0.0-SNAPSHOT
-bundle:watch --start mvn:ca.islandora.camel.services/islandora-basic-image-service/0.0.0-SNAPSHOT
+bundle:watch --start mvn:ca.islandora.camel.component/islandora-camel-component/0.0.1-SNAPSHOT
+bundle:watch --start mvn:ca.islandora.camel.sync/islandora-sync-gateway/0.0.1-SNAPSHOT
+bundle:watch --start mvn:ca.islandora.camel.services/islandora-collection-service/0.0.1-SNAPSHOT
+bundle:watch --start mvn:ca.islandora.camel.services/islandora-basic-image-service/0.0.1-SNAPSHOT
 logout


### PR DESCRIPTION
A 0.0.0-SNAPSHOT version doesn't make any sense to me (we're not preparing for a 0.0.0 release).

This also removes a few superfluous version declarations from the pom files.