### PR TITLE
Override port 80 mappings for additional providers. Address #76.

### DIFF
--- a/install/Vagrantfile
+++ b/install/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     override.vm.box = "dummy"
     override.ssh.username = "ubuntu"
     override.ssh.private_key_path = ENV['AWS_KEYPATH']
-    config.vm.network :forwarded_port, guest: 80, host: 80
+    override.vm.network :forwarded_port, guest: 80, host: 80
   end
   
   # This should work fine out of the box if environment variables are declared
@@ -39,10 +39,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     provider.image = 'ubuntu-14-04-x64'
     provider.region = 'tor1'
     provider.size = '4gb'
-    config.vm.network :forwarded_port, guest: 80, host: 80
+    override.vm.network :forwarded_port, guest: 80, host: 80
   end
   
-    # Every Vagrant virtual environment requires a box to build off of.
+  # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/trusty64"
 
   # Setup the shared folder


### PR DESCRIPTION
This resolves #76.

```
 ==> default: Forwarding ports...
    default: 8080 => 8080 (adapter 1)
    default: 8181 => 8181 (adapter 1)
    default: 3306 => 3306 (adapter 1)
    default: 5432 => 5432 (adapter 1)
    default: 80 => 8000 (adapter 1)
    default: 22 => 2222 (adapter 1)
```
![screenshot from 2015-10-13 20 50 57](https://cloud.githubusercontent.com/assets/218561/10472223/1f603222-71ec-11e5-8385-73061d37f596.png)

